### PR TITLE
Fix trailing commas in function calls.

### DIFF
--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -141,7 +141,7 @@ class SettingsController extends Controller
             'entryQueries',
             'entryMutations',
             'assetQueries',
-            'assetMutations',
+            'assetMutations'
         ));
     }
 
@@ -238,7 +238,7 @@ class SettingsController extends Controller
             'entryQueries',
             'entryMutations',
             'assetQueries',
-            'assetMutations',
+            'assetMutations'
         );
     }
 }

--- a/src/services/SocialService.php
+++ b/src/services/SocialService.php
@@ -377,7 +377,7 @@ class SocialService extends Component
         return compact(
             'email',
             'firstName',
-            'lastName',
+            'lastName'
         );
     }
 
@@ -410,7 +410,7 @@ class SocialService extends Component
         return compact(
             'email',
             'firstName',
-            'lastName',
+            'lastName'
         );
     }
 
@@ -447,7 +447,7 @@ class SocialService extends Component
         return compact(
             'email',
             'firstName',
-            'lastName',
+            'lastName'
         );
     }
 }

--- a/src/services/TokenService.php
+++ b/src/services/TokenService.php
@@ -147,12 +147,12 @@ class TokenService extends Component
                             try {
                                 $jwtConfig = Configuration::forSymmetricSigner(
                                     new Sha256(),
-                                    InMemory::plainText($settings->jwtSecretKey),
+                                    InMemory::plainText($settings->jwtSecretKey)
                                 );
 
                                 $validator = new SignedWith(
                                     new Sha256(),
-                                    InMemory::plainText($settings->jwtSecretKey),
+                                    InMemory::plainText($settings->jwtSecretKey)
                                 );
 
                                 $jwtConfig->setValidationConstraints($validator);
@@ -246,7 +246,7 @@ class TokenService extends Component
 
         $jwtConfig = Configuration::forSymmetricSigner(
             new Sha256(),
-            InMemory::plainText($settings->jwtSecretKey),
+            InMemory::plainText($settings->jwtSecretKey)
         );
 
         $now = new DateTimeImmutable();


### PR DESCRIPTION
Trailing commas are not valid syntax in PHP < 7.3.