### PR TITLE
Allowing to set the social settings with environnement variables

### DIFF
--- a/src/GraphqlAuthentication.php
+++ b/src/GraphqlAuthentication.php
@@ -139,4 +139,13 @@ class GraphqlAuthentication extends Plugin
         $event->rules['POST graphql-authentication/settings'] = 'graphql-authentication/settings/save';
         $event->rules['graphql-authentication/settings'] = 'graphql-authentication/settings/index';
     }
+
+    public function getSettingsData(string $setting): string
+    {
+        if (Craft::parseEnv($setting)) {
+            return Craft::parseEnv($setting);
+        } else {
+            return $setting;
+        }
+    }
 }

--- a/src/services/AppleService.php
+++ b/src/services/AppleService.php
@@ -57,8 +57,12 @@ class AppleService extends Component
                 $url = 'https://appleid.apple.com/auth/authorize?' . http_build_query([
                     'response_type' => 'code',
                     'response_mode' => 'form_post',
-                    'client_id' => $settings->appleClientId,
-                    'redirect_uri' => $settings->appleRedirectUrl,
+                    'client_id' => GraphqlAuthentication::$plugin->getSettingsData(
+                        $settings->appleClientId
+                    ),
+                    'redirect_uri' => GraphqlAuthentication::$plugin->getSettingsData(
+                        $settings->appleRedirectUrl
+                    ),
                     'state' => $state,
                     'scope' => 'name email',
                 ]);
@@ -163,9 +167,11 @@ class AppleService extends Component
                 'form_params' => [
                     'grant_type' => 'authorization_code',
                     'code' => $code,
-                    'client_id' => $settings->appleClientId,
-                    'client_secret' => $settings->appleClientSecret,
-                    'redirect_uri' => $settings->appleRedirectUrl,
+                    'client_id' => GraphqlAuthentication::$plugin->getSettingsData(
+                        $settings->appleClientId
+                    ),
+                    'client_secret' => GraphqlAuthentication::$plugin->getSettingsData($settings->appleClientSecret),
+                    'redirect_uri' => GraphqlAuthentication::$plugin->getSettingsData($settings->appleRedirectUrl),
                 ],
             ])->getBody()->getContents());
         } catch (Throwable $e) {

--- a/src/services/FacebookService.php
+++ b/src/services/FacebookService.php
@@ -50,11 +50,18 @@ class FacebookService extends Component
                 $settings = GraphqlAuthentication::$plugin->getSettings();
 
                 $client = new Facebook([
-                    'app_id' => $settings->facebookAppId,
-                    'app_secret' => $settings->facebookAppSecret,
+                    'app_id' => GraphqlAuthentication::$plugin->getSettingsData(
+                        $settings->facebookAppId
+                    ),
+                    'app_secret' => GraphqlAuthentication::$plugin->getSettingsData(
+                        $settings->facebookAppSecret
+                    ),
                 ]);
 
-                $url = $client->getRedirectLoginHelper()->getLoginUrl($settings->facebookRedirectUrl, ['email']);
+                $url = $client->getRedirectLoginHelper()->getLoginUrl(
+                    GraphqlAuthentication::$plugin->getSettingsData($settings->facebookRedirectUrl),
+                    ['email']
+                );
                 return $url;
             },
         ];
@@ -140,11 +147,15 @@ class FacebookService extends Component
         $errorService = GraphqlAuthentication::$plugin->getInstance()->error;
 
         $client = new Facebook([
-            'app_id' => $settings->facebookAppId,
-            'app_secret' => $settings->facebookAppSecret,
+            'app_id' => GraphqlAuthentication::$plugin->getSettingsData(
+                $settings->facebookAppId
+            ),
+            'app_secret' => GraphqlAuthentication::$plugin->getSettingsData(
+                $settings->facebookAppSecret
+            ),
         ]);
 
-        $accessToken = $client->getOAuth2Client()->getAccessTokenFromCode($code, $settings->facebookRedirectUrl);
+        $accessToken = $client->getOAuth2Client()->getAccessTokenFromCode($code, GraphqlAuthentication::$plugin->getSettingsData($settings->facebookRedirectUrl));
 
         if (!$accessToken) {
             $errorService->throw($settings->invalidOauthToken, 'INVALID');

--- a/src/services/GoogleService.php
+++ b/src/services/GoogleService.php
@@ -107,7 +107,9 @@ class GoogleService extends Component
     {
         $settings = GraphqlAuthentication::$plugin->getSettings();
         $errorService = GraphqlAuthentication::$plugin->getInstance()->error;
-        $client = new Google_Client(['client_id' => $settings->googleClientId]);
+        $client = new Google_Client([
+            'client_id' => GraphqlAuthentication::$plugin->getSettingsData($settings->googleClientId)
+        ]);
         $payload = $client->verifyIdToken($idToken);
 
         if (!$payload) {

--- a/src/services/TwitterService.php
+++ b/src/services/TwitterService.php
@@ -48,8 +48,17 @@ class TwitterService extends Component
             'args' => [],
             'resolve' => function () {
                 $settings = GraphqlAuthentication::$plugin->getSettings();
-                $client = new TwitterOAuth($settings->twitterApiKey, $settings->twitterApiKeySecret);
-                $requestToken = $client->oauth('oauth/request_token', ['oauth_callback' => $settings->twitterRedirectUrl]);
+                $client = new TwitterOAuth(
+                    GraphqlAuthentication::$plugin->getSettingsData($settings->twitterApiKey),
+                    GraphqlAuthentication::$plugin->getSettingsData($settings->twitterApiKeySecret)
+                );
+                $requestToken = $client->oauth(
+                    'oauth/request_token',
+                    [
+                        'oauth_callback' =>
+                        GraphqlAuthentication::$plugin->getSettingsData($settings->twitterRedirectUrl)
+                    ]
+                );
 
                 $oauthToken = $requestToken['oauth_token'];
                 $oauthTokenSecret = $requestToken['oauth_token_secret'];
@@ -153,10 +162,20 @@ class TwitterService extends Component
             $errorService->throw($settings->invalidOauthToken, 'INVALID');
         }
 
-        $client = new TwitterOAuth($settings->twitterApiKey, $settings->twitterApiKeySecret, $sessionOauthToken, $sessionOauthTokenSecret);
+        $client = new TwitterOAuth(
+            GraphqlAuthentication::$plugin->getSettingsData($settings->twitterApiKey),
+            GraphqlAuthentication::$plugin->getSettingsData($settings->twitterApiKeySecret),
+            $sessionOauthToken,
+            $sessionOauthTokenSecret
+        );
         $accessToken = $client->oauth('oauth/access_token', ['oauth_verifier' => $oauthVerifier]);
 
-        $client = new TwitterOAuth($settings->twitterApiKey, $settings->twitterApiKeySecret, $accessToken['oauth_token'], $accessToken['oauth_token_secret']);
+        $client = new TwitterOAuth(
+            GraphqlAuthentication::$plugin->getSettingsData($settings->twitterApiKey),
+            GraphqlAuthentication::$plugin->getSettingsData($settings->twitterApiKeySecret),
+            $accessToken['oauth_token'],
+            $accessToken['oauth_token_secret']
+        );
         $user = $client->get('account/verify_credentials', ['include_email' => true, 'entities' => false, 'skip_status' => true]);
 
         $email = $user->email;

--- a/src/templates/_sections/social.twig
+++ b/src/templates/_sections/social.twig
@@ -15,13 +15,14 @@
   first: true,
 }, null) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'Client ID',
   instructions: 'The client ID from your Google OAuth project.',
   name: 'googleClientId',
   value: settings.googleClientId,
   placeholder: 'xxxx-xxxx.apps.googleusercontent.com',
   required: false,
+  suggestEnvVars: true,
 }) }}
 
 {{ forms.textField({
@@ -41,31 +42,34 @@
   first: true,
 }, null) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'App ID',
   instructions: 'The App ID from your Facebook app.',
   name: 'facebookAppId',
   value: settings.facebookAppId,
   placeholder: 'xxxxxxxxxxxxxxxx',
   required: false,
+  suggestEnvVars: true,
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'App Secret',
   instructions: 'The App Secret from your Facebook app.',
   name: 'facebookAppSecret',
   value: settings.facebookAppSecret,
   placeholder: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
   required: false,
+  suggestEnvVars: true,
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'Redirect URL',
   instructions: 'The URL to redirect to after authenticating.',
   name: 'facebookRedirectUrl',
   value: settings.facebookRedirectUrl,
   placeholder: 'https://yoursite.com/redirect',
   required: false,
+  suggestEnvVars: true,
 }) }}
 
 {{ forms.textField({
@@ -85,31 +89,34 @@
   first: true,
 }, null) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'API Key',
   instructions: 'The API Key from your Twitter app.',
   name: 'twitterApiKey',
   value: settings.twitterApiKey,
   placeholder: 'xxxxxxxxxxxxxxxxxxxxxxxxx',
   required: false,
+  suggestEnvVars: true,
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'API Key Secret',
   instructions: 'The API Key Secret from your Twitter app.',
   name: 'twitterApiKeySecret',
   value: settings.twitterApiKeySecret,
   placeholder: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
   required: false,
+  suggestEnvVars: true,
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'Redirect URL',
   instructions: 'The URL to redirect to after authenticating.',
   name: 'twitterRedirectUrl',
   value: settings.twitterRedirectUrl,
   placeholder: 'https://yoursite.com/redirect',
   required: false,
+  suggestEnvVars: true,
 }) }}
 
 {{ forms.textField({
@@ -129,25 +136,27 @@
   first: true,
 }, null) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'App Client ID',
   instructions: 'The App Client ID from your Apple app.',
   name: 'appleClientId',
   value: settings.appleClientId,
   placeholder: 'com.yourapp.id',
   required: false,
+  suggestEnvVars: true,
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'App Client Secret',
   instructions: 'The App Client Secret from your Apple app.',
   name: 'appleClientSecret',
   value: settings.appleClientSecret,
   placeholder: 'xxxxxxxxxx',
   required: false,
+  suggestEnvVars: true,
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
   label: 'Redirect URL',
   instructions: 'The URL to redirect to after authenticating.',
   name: 'appleRedirectUrl',


### PR DESCRIPTION
Adding the possibility to add environnement variables for the social details.

For example, you can now add variables like
```
FACEBOOK_REDIRECT_URL=
FACEBOOK_APP_SECRET=
FACEBOOK_APP_ID=
```

in your .env file and add $FACEBOOK_REDIRECT_URL to the wanted field and it will take the value instead. If there is none, it will take the value of the field as a string.

It is useful for testing purposes in different environnements.