### PR TITLE
Fix + Adding username

### DIFF
--- a/src/services/UserService.php
+++ b/src/services/UserService.php
@@ -176,6 +176,8 @@ class UserService extends Component
                             'password' => Type::nonNull(Type::string()),
                             'firstName' => Type::nonNull(Type::string()),
                             'lastName' => Type::nonNull(Type::string()),
+                            'firstName' => Type::string(),
+                            'lastName' => Type::string(),
                         ],
                         UserArguments::getContentArguments()
                     ),

--- a/src/services/UserService.php
+++ b/src/services/UserService.php
@@ -138,6 +138,7 @@ class UserService extends Component
                         'password' => Type::nonNull(Type::string()),
                         'firstName' => Type::string(),
                         'lastName' => Type::string(),
+                        'username' => Type::string(),
                         'preferredLanguage' => Type::string(),
                     ],
                     UserArguments::getContentArguments()
@@ -174,10 +175,9 @@ class UserService extends Component
                         [
                             'email' => Type::nonNull(Type::string()),
                             'password' => Type::nonNull(Type::string()),
-                            'firstName' => Type::nonNull(Type::string()),
-                            'lastName' => Type::nonNull(Type::string()),
                             'firstName' => Type::string(),
                             'lastName' => Type::string(),
+                            'username' => Type::string(),
                         ],
                         UserArguments::getContentArguments()
                     ),
@@ -345,6 +345,7 @@ class UserService extends Component
                     'email' => Type::string(),
                     'firstName' => Type::string(),
                     'lastName' => Type::string(),
+                    'username' => Type::string(),
                     'preferredLanguage' => Type::string(),
                 ],
                 UserArguments::getContentArguments()
@@ -359,11 +360,15 @@ class UserService extends Component
                 $email = $arguments['email'];
                 $firstName = $arguments['firstName'];
                 $lastName = $arguments['lastName'];
+                $username = $arguments['username'];
                 $preferredLanguage = $arguments['preferredLanguage'];
 
                 if (isset($email)) {
-                    $user->username = $email;
                     $user->email = $email;
+                }
+
+                if (isset($username)) {
+                    $user->username = $username;
                 }
 
                 if (isset($firstName)) {
@@ -459,9 +464,10 @@ class UserService extends Component
         $password = $arguments['password'];
         $firstName = $arguments['firstName'];
         $lastName = $arguments['lastName'];
+        $username = isset($arguments['username']) ? $arguments['username'] : $email;
 
         $user = new User();
-        $user->username = $email;
+        $user->username = $username;
         $user->email = $email;
         $user->firstName = $firstName;
         $user->lastName = $lastName;


### PR DESCRIPTION
Hi!!

I made this request for two reasons:

1) The username is sometimes required upon registering when you don't use the config `useEmailAsUsername`. More over we didn't want it to be the email so I added an option to pass the username when registering. If it is not there, it will take the email by default

2) The first and last name were not optionals in the multiple schemas 

I hope this makes sens :)

Thanks for all your work