### PR TITLE
Allow username in `register{handle}` mutation

### DIFF
--- a/src/services/UserService.php
+++ b/src/services/UserService.php
@@ -218,6 +218,7 @@ class UserService extends Component
                         [
                             'email' => Type::nonNull(Type::string()),
                             'password' => Type::nonNull(Type::string()),
+                            'username' => Type::string(),
                             'firstName' => Type::string(),
                             'lastName' => Type::string(),
                             'preferredLanguage' => Type::string(),


### PR DESCRIPTION
Allow username to be sent on registration of user when using multiple user groups.