### PR TITLE
Checking for authorId with mutation event

### DIFF
--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -326,7 +326,9 @@ class RestrictionService extends Component
         $user = GraphqlAuthentication::$tokenService->getUserFromToken();
 
         if ($event->isNew) {
-            $event->sender->authorId = $user->id;
+            if (!isset($event->sender->authorId)) {
+              $event->sender->authorId = $user->id;
+            }
             return true;
         }
 


### PR DESCRIPTION
I'm trying to create new entries and set the author to be someone other than the logged-in user. 

The RestrictionService is currently setting all new events to have the same authorId as the user, without checking for an authorId being supplied with the mutation. I'm just adding a check for that, and using the supplied authorId if there is one. I'm not sure of the wider security implications.