### PR TITLE
Allow empty strings, empty arrays and null values to set on user custom fields

### DIFF
--- a/src/services/UserService.php
+++ b/src/services/UserService.php
@@ -585,17 +585,11 @@ class UserService extends Component
                 $key = $key['name'];
             }
 
-            $value = $arguments[$key] ?? null;
-
-            if (!isset($value) || (!$value && gettype($value) !== 'boolean')) {
+            if (!array_key_exists($key, $arguments)) {
                 continue;
             }
 
-            if (is_array($value) && !count($value)) {
-                continue;
-            }
-
-            $user->setFieldValue($key, $value);
+            $user->setFieldValue($key, $arguments[$key]);
         }
     }
 


### PR DESCRIPTION
Hey James,

Thanks for your work on that plugin in advance! ;)

But don't you think that resetting custom fields on a user should'nt be allowed?
We have custom fields like "homepage" a user can set. Unsetting that value isn't possible right now.
I hope the change I've made still makes sence, cause I think checking for the key to exist on the arguments array should be enough, right?

Cheers
Hendrik