### PR TITLE
Correctly check for account manual activation flag

### DIFF
--- a/src/services/UserService.php
+++ b/src/services/UserService.php
@@ -511,8 +511,9 @@ class UserService extends Component
         /** @var ProjectConfig */
         $projectConfigService = Craft::$app->getProjectConfig();
         $requiresVerification = $projectConfigService->get('users.requireEmailVerification');
+        $suspendByDefault = $projectConfigService->get('users.suspendByDefault');
 
-        if ($requiresVerification) {
+        if ($requiresVerification || $suspendByDefault) {
             $user->pending = true;
         }
 


### PR DESCRIPTION
Hi, 
i'm using this module in a project which requires user registration via gQL API and it's working wonders!
I need in my project to manually approve user registration though, and I used the craft setting to wait for manual approval. To my surprise it did not apply to the gQL registered users. I checked the code and found out that this plugin was missing to check for that flag. 
I added support for the flag and tested it out. 
Let me know if i missed something and thanks for your work :)
