### PR TITLE
Fix a validation error that occurred when setting a password for a user with an unverified email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fixed migration issue that occurred when setting a password for users with an unverified email (created in the control panel)
+
 ## 1.12.1 - 2021-11-09
 
 ### Fixed

--- a/src/services/UserService.php
+++ b/src/services/UserService.php
@@ -329,6 +329,7 @@ class UserService extends Component
                 }
 
                 $user->newPassword = $password;
+                $user->setScenario(User::SCENARIO_PASSWORD);
 
                 if (!$elementsService->saveElement($user)) {
                     $errors = $user->getErrors();


### PR DESCRIPTION
When setting a password, we must set the validation scenarion to `SCENARIO_PASSWORD`, to make sure only the password fields are validated.
Otherwise a validation error will be thrown for users with an unverified email.

With this fix, such users are correctly activated, after setting the password, and hence their email is no longer unverified.