### PR TITLE
feature: Handle the user.passwordResetRequired flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+### Added
+
+- The password reset required flag is now honorred. When a user having this flag set tries to authenticate, an password reset email is sent and an according error message is returned
+
 ### Fixed
 
 - Fixed migration issue that occurred when setting a password for users with an unverified email (created in the control panel)

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -72,6 +72,7 @@ class Settings extends Model
     public $passwordSaved = 'Successfully saved password';
     public $passwordUpdated = 'Successfully updated password';
     public $passwordResetSent = 'You will receive an email if it matches an account in our system';
+    public $passwordResetRequired = 'Password reset required; please check your email';
 
     public $tokenNotFound = "We couldn't find any matching tokens";
     public $userNotFound = "We couldn't find any matching users";

--- a/src/services/UserService.php
+++ b/src/services/UserService.php
@@ -143,6 +143,11 @@ class UserService extends Component
                 }
 
                 if (!$user->authenticate($password)) {
+                    if ($user->authError === User::AUTH_PASSWORD_RESET_REQUIRED) {
+                        Craft::$app->getUsers()->sendPasswordResetEmail($user);
+                        $errorService->throw($settings->passwordResetRequired, true);
+                    }
+
                     $permissionsService->saveUserPermissions($user->id, $userPermissions);
                     $errorService->throw($settings->invalidLogin);
                 }

--- a/src/templates/_sections/messages.twig
+++ b/src/templates/_sections/messages.twig
@@ -52,6 +52,13 @@
   required: true,
 }) }}
 
+{{ forms.textField({
+  label: 'Password Reset Required',
+  name: 'passwordResetRequired',
+  value: settings.passwordResetRequired,
+  required: true,
+}) }}
+
 <hr/>
 <h2>Invalid</h2>
 


### PR DESCRIPTION
When a user having the `passwordResetRequired` flag set tries to authenticate, the following happens:

- a password reset email is sent
- an error message instructing him to check his emails is returned

FYI, I think you may be missing the second parameter set to `true` in several calls to `$errorService->throw()`. This cause cryptic error to be returned instead of themessage defined in the settings.