### PR TITLE
Fix for the issue #112

### DIFF
--- a/src/services/UserService.php
+++ b/src/services/UserService.php
@@ -528,6 +528,7 @@ class UserService extends Component
         $user = new User();
         $user->username = $email;
         $user->email = $email;
+        $user->active = true;
 
         if ($username) {
             $user->username = $username;
@@ -552,6 +553,7 @@ class UserService extends Component
         $skipSocialActivation = $settings->skipSocialActivation;
 
         if ($requiresVerification || $suspendByDefault) {
+            $user->active = false;
             $user->pending = true;
         }
 


### PR DESCRIPTION
Fix for the issue [#112](https://github.com/jamesedmonston/graphql-authentication/issues/112)

In Craft 4.* User element has active Boolean set to false by default ([source](https://docs.craftcms.com/api/v4/craft-elements-user.html#public-properties ))

This way currently in the `create` function of `UserService`active flag is changed to true only in case  ` if ($social && $skipSocialActivation)` condition returns true.

I've added the following changes:

1) set the default active value to _true_:
```
      $user = new User();
      $user->username = $email;
      $user->email = $email;
      $user->active = true;
```
2) when `if ($requiresVerification || $suspendByDefault)` condition is true, set the active flag back to false:

```
if ($requiresVerification || $suspendByDefault) {
      $user->active = false;
      $user->pending = true;
}
```

Hope that resolves the issue (in my case it does)

