### PR TITLE
Update RestrictionService.php to include $user is defined check

### DIFF
--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -441,7 +441,8 @@ class RestrictionService extends Component
             return true;
         }
 
-        $authorOnlyVolumes = $this->getAuthorOnlyVolumes($user, 'mutation');
+        // Robin Beatty: added user check here
+        $authorOnlyVolumes = isset($user) && $user ? $this->getAuthorOnlyVolumes($user, 'mutation') : [];
 
         /** @var Volumes */
         $volumesService = Craft::$app->getVolumes();
@@ -655,7 +656,8 @@ class RestrictionService extends Component
             $errorService->throw($settings->forbiddenMutation);
         }
 
-        $authorOnlyVolumes = $this->getAuthorOnlyVolumes($user, 'mutation');
+        // Robin Beatty: added user check here
+        $authorOnlyVolumes = isset($user) && $user ? $this->getAuthorOnlyVolumes($user, 'mutation') : [];
 
         /** @var Volumes */
         $volumesService = Craft::$app->getVolumes();


### PR DESCRIPTION
In my installation, an error was being thrown when calling getAuthorOnlyVolumes because $user was not defined. Not 100% sure why it wasn't defined: Maybe got disassociated from the token at some point, or original entry was created by a user that no longer exists. This test solves the problem for me.

"exception": "[object] (Error(code: 0): Call to a member function getGroups() on null at /home/737861.cloudwaysapps.com/vsxqdmbexx/public_html/craft/vendor/jamesedmonston/graphql-authentication/src/services/RestrictionService.php:518)"