### PR TITLE
fixed php 7.4 compatibility for craft3

### DIFF
--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -211,7 +211,7 @@ class RestrictionService extends Component
                         /** @var GqlToken */
                         $token = $gqlService->getTokenByAccessToken($matches[1]);
                         $schema = $token->getSchema();
-                    } catch (InvalidArgumentException) {
+                    } catch (InvalidArgumentException $e) {
                     }
 
                     break 2;


### PR DESCRIPTION
php 7.4 doesn't support catch without capturing the exception