### PR TITLE
Pass error message if user is not activated 

### DIFF
--- a/src/services/TokenService.php
+++ b/src/services/TokenService.php
@@ -548,7 +548,7 @@ class TokenService extends Component
         }
 
         if ($user->status !== 'active' && !$settings->skipActivatedCheck) {
-            $errorService->throw($settings->userNotActivated);
+            $errorService->throw($settings->userNotActivated, true);
         }
     }
 


### PR DESCRIPTION
We noticed this when after the user receives the activate email, but does not activate it, then they return to this page, they receive the generic "Something went wrong when processing the GraphQL query." message from craft.  This change should pass on "Please activate your account" instead.

This sets the validate function error to pass the error message if the user is not activated.

Here's the trace for the error:
```
    "trace": [
        "#0 /app/shared/storage/vendor/jamesedmonston/graphql-authentication/src/services/TokenService.php(551): jamesedmonston\\graphqlauthentication\\services\\ErrorService->throw('Please activate...')",
        "#1 /app/shared/storage/vendor/jamesedmonston/graphql-authentication/src/services/TokenService.php(243): jamesedmonston\\graphqlauthentication\\services\\TokenService->_validateToken(Object(Lcobucci\\JWT\\Token\\Plain))",
        "#2 /app/shared/storage/vendor/jamesedmonston/graphql-authentication/src/services/TokenService.php(255): jamesedmonston\\graphqlauthentication\\services\\TokenService->getHeaderToken()",
        "#3 [internal function]: jamesedmonston\\graphqlauthentication\\services\\TokenService->setActiveSchema(Object(craft\\events\\ExecuteGqlQueryEvent))",
        "#4 /app/shared/storage/vendor/yiisoft/yii2/base/Event.php(312): call_user_func(Array, Object(craft\\events\\ExecuteGqlQueryEvent))",
        "#5 /app/shared/storage/vendor/yiisoft/yii2/base/Component.php(642): yii\\base\\Event::trigger('craft\\\\services\\\\...', 'beforeExecuteGq...', Object(craft\\events\\ExecuteGqlQueryEvent))",
        "#6 /app/shared/storage/vendor/craftcms/cms/src/services/Gql.php(487): yii\\base\\Component->trigger('beforeExecuteGq...', Object(craft\\events\\ExecuteGqlQueryEvent))",
        "#7 /app/shared/storage/vendor/craftcms/cms/src/controllers/GraphqlController.php(195): craft\\services\\Gql->executeQuery(Object(craft\\models\\GqlSchema), 'mutation Authen...', Array, 'AuthenticateUse...', false)",
        "#8 [internal function]: craft\\controllers\\GraphqlController->actionApi()",
        "#9 /app/shared/storage/vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array(Array, Array)",
        "#10 /app/shared/storage/vendor/yiisoft/yii2/base/Controller.php(178): yii\\base\\InlineAction->runWithParams(Array)",
        "#11 /app/shared/storage/vendor/yiisoft/yii2/base/Module.php(552): yii\\base\\Controller->runAction('api', Array)",
        "#12 /app/shared/storage/vendor/craftcms/cms/src/web/Application.php(305): yii\\base\\Module->runAction('graphql/api', Array)",
        "#13 /app/shared/storage/vendor/yiisoft/yii2/web/Application.php(103): craft\\web\\Application->runAction('graphql/api', Array)",
        "#14 /app/shared/storage/vendor/craftcms/cms/src/web/Application.php(290): yii\\web\\Application->handleRequest(Object(craft\\web\\Request))",
        "#15 /app/shared/storage/vendor/yiisoft/yii2/base/Application.php(384): craft\\web\\Application->handleRequest(Object(craft\\web\\Request))",
        "#16 /app/releases/release-20240307171144/public/index.php(12): yii\\base\\Application->run()",
        "#17 {main}"
    ],
    "exception": "[object] (GraphQL\\Error\\Error(code: 0): Please activate your account before logging in at /app/shared/storage/vendor/jamesedmonston/graphql-authentication/src/services/ErrorService.php:28)"
}
```
And some additional information caught in the logs.  The cookie is notable because, if it does not exist, the code takes a different path through UserService.php(136), and returns the "Please activate your account" message.
```
{
    "environment": "staging",
    "body": "{\"query\":\"mutation AuthenticateUser($email: String!, $password: String!) { authenticate(email: $email, password: $password) { __typename jwt jwtExpiresAt refreshToken refreshTokenExpiresAt } }\",\"operationName\":\"AuthenticateUser\",\"variables\":{\"email\":\"valid@example.com\",\"password\":\"••••••••••\"}}",
    "vars": {
        "_GET": {
            "p": "api/"
        },
        "_FILES": [],
        "_COOKIE": {
            "_ia": "2658dbe8-efb6-4487-b0f7-6b1b9781e45b.1",
            "gql_refreshToken": "••••••••••••••••••••••••••••••••",
            "CraftSessionId": "d9476d0e248832f818221d663a08e18c"
        },
        . . .
    }
}
```