### PR TITLE
Fix Craft 5.6+ compatibility

### DIFF
--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -111,7 +111,7 @@ class RestrictionService extends Component
 
         foreach (Craft::$app->getEntries()->getAllSections() as $section) {
             // "Entries" was added in Craft 5.6.5
-            $resolvers[$name] = EntryResolver::class . '::resolve';
+            $resolvers[$section->handle] = EntryResolver::class . '::resolve';
             $resolvers["{$section->handle}Entries"] = EntryResolver::class . '::resolve';
         }
 


### PR DESCRIPTION
`EntryArguments::getArguments()` no longer includes custom fields in Craft 5.6.0+ (https://github.com/craftcms/cms/pull/16326).

Rather that update `registerGqlQueries()` to be consistent with how Craft defines entry queries, this PR simplifies the function to just figure out which queries are already defined by `$event->queries`, and only overwrite their `resolver` properties.

Fixes #160