### PR TITLE
Fix #163: Add sectionId checking logic

### DIFF
--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -344,14 +344,11 @@ class RestrictionService extends Component
 
         $entriesService = Craft::$app->getEntries();
         
-        // check if element has a section id, if not look for the root owner (in case of nested matrix).
-        $sectionIdToCheck = $entry->sectionId ? $entry->sectionId : ($entry->getRootOwner() ? $entry->getRootOwner()->sectionId : null);
-        
         // If there is no section id bypass this check
-        if (!$sectionIdToCheck) {
+        if (!$entry->sectionId) {
             return true;
         }
-        $entrySection = $entriesService->getSectionById($sectionIdToCheck)->handle;
+        $entrySection = $entriesService->getSectionById($entry->sectionId)->handle;
 
         if (!in_array($entrySection, $authorOnlySections)) {
             return true;

--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -344,11 +344,10 @@ class RestrictionService extends Component
 
         $entriesService = Craft::$app->getEntries();
         
-        // If there is no section id bypass this check
-        if (!$entry->sectionId) {
-            return true;
-        }
-        $entrySection = $entriesService->getSectionById($entry->sectionId)->handle;
+        // If there is no section id this is a nested entry (aka matrix block), look for the root owner's section id.
+        $sectionIdToTest = $entry->sectionId ? $entry->sectionId : $entry->getRootOwner()->sectionId;
+        
+        $entrySection = $entriesService->getSectionById($sectionIdToTest)->handle;
 
         if (!in_array($entrySection, $authorOnlySections)) {
             return true;

--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -343,7 +343,15 @@ class RestrictionService extends Component
         $authorOnlySections = $user ? $this->getAuthorOnlySections($user, 'mutation') : [];
 
         $entriesService = Craft::$app->getEntries();
-        $entrySection = $entriesService->getSectionById($entry->sectionId)->handle;
+        
+        // check if element has a section id, if not look for the root owner (in case of nested matrix).
+        $sectionIdToCheck = $entry->sectionId ? $entry->sectionId : ($entry->getRootOwner() ? $entry->getRootOwner()->sectionId : null);
+        
+        // If there is no section id bypass this check
+        if (!$sectionIdToCheck) {
+            return true;
+        }
+        $entrySection = $entriesService->getSectionById($sectionIdToCheck)->handle;
 
         if (!in_array($entrySection, $authorOnlySections)) {
             return true;


### PR DESCRIPTION
Fixes #163 by checking for an entry's root owner's `sectionId` when `sectionId` is null before seeing if this is an authorized section to mutate.  This happens when an entry is a matrix block.