### PR TITLE
Deprecation warning fix

### DIFF
--- a/src/elements/MagicCode.php
+++ b/src/elements/MagicCode.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\base\Element;
 use craft\elements\actions\Delete;
 use craft\elements\db\ElementQueryInterface;
+use craft\helpers\Cp;
 use jamesedmonston\graphqlauthentication\elements\db\MagicCodeQuery;
 
 class MagicCode extends Element
@@ -65,7 +66,7 @@ class MagicCode extends Element
             case 'userId':
                 $usersService = Craft::$app->getUsers();
                 $user = $usersService->getUserById($this->userId);
-                return $user ? Craft::$app->getView()->renderTemplate('_elements/element', ['element' => $user]) : '';
+                return $user ? Cp::elementChipHtml($user) : '';
 
             case 'schemaName':
                 $gqlService = Craft::$app->getGql();

--- a/src/elements/RefreshToken.php
+++ b/src/elements/RefreshToken.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\base\Element;
 use craft\elements\actions\Delete;
 use craft\elements\db\ElementQueryInterface;
+use craft\helpers\Cp;
 use jamesedmonston\graphqlauthentication\elements\db\RefreshTokenQuery;
 
 class RefreshToken extends Element
@@ -65,7 +66,7 @@ class RefreshToken extends Element
             case 'userId':
                 $usersService = Craft::$app->getUsers();
                 $user = $usersService->getUserById($this->userId);
-                return $user ? Craft::$app->getView()->renderTemplate('_elements/element', ['element' => $user]) : '';
+                return $user ? Cp::elementChipHtml($user) : '';
 
             case 'schemaName':
                 $gqlService = Craft::$app->getGql();


### PR DESCRIPTION
Hi, just a small fix for a deprecation warning I've noticed happening in Craft 5 - I've tested locally and using the suggested `Cp::elementChipHtml` [helper function](https://docs.craftcms.com/api/v5/craft-helpers-cp.html#method-elementchiphtml) appears to work as far as I can tell

<img width="1254" height="189" alt="Screenshot 2025-07-14 at 1 09 51 pm" src="https://github.com/user-attachments/assets/2519cf60-2583-42ac-9131-fe00bff03476" />
<img width="1160" height="770" alt="Screenshot 2025-07-14 at 1 10 11 pm" src="https://github.com/user-attachments/assets/3bcdf592-e1d2-4c28-adf1-aa980e1c96fd" />
