### PR TITLE
fix: dont assume public schema has id of 1

### DIFF
--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -108,8 +108,8 @@ class SettingsController extends Controller
 
         foreach ($schemas as $schema) {
             $schemaOptions[] = [
-                'label' => $schema->name,
-                'value' => $schema->name,
+                'label' => $schema->isPublic ? 'Public' : $schema->name,
+                'value' => $schema->isPublic ? 'public' : $schema->name,
             ];
         }
 
@@ -120,9 +120,15 @@ class SettingsController extends Controller
         $assetQueries = null;
         $assetMutations = null;
 
-        if ($settings->permissionType === 'single' && $settings->schemaName && $settings->schemaName !== $publicSchema->name) {
-            $schemaId = GqlSchemaRecord::find()->select(['id'])->where(['name' => $settings->schemaName])->scalar();
-            $schemaPermissions = $this->_getSchemaPermissions($gqlService->getSchemaById($schemaId));
+        if ($settings->permissionType === 'single' && $settings->schemaName) {
+            if ($settings->schemaName === 'public') {
+                // For public schema, get it directly
+                $schemaPermissions = $this->_getSchemaPermissions($publicSchema);
+            } else {
+                // For named schemas, find by name
+                $schemaId = GqlSchemaRecord::find()->select(['id'])->where(['name' => $settings->schemaName])->scalar();
+                $schemaPermissions = $this->_getSchemaPermissions($gqlService->getSchemaById($schemaId));
+            }
             $entryQueries = $schemaPermissions['entryQueries'];
             $entryMutations = $schemaPermissions['entryMutations'];
             $assetQueries = $schemaPermissions['assetQueries'];
@@ -132,13 +138,20 @@ class SettingsController extends Controller
         if ($settings->permissionType === 'multiple') {
             foreach ($userGroups as $userGroup) {
                 $schemaName = $settings->granularSchemas['group-' . $userGroup->id]['schemaName'] ?? null;
-                $schemaId = GqlSchemaRecord::find()->select(['id'])->where(['name' => $schemaName])->scalar();
 
-                if (!$schemaId || $schemaName === $publicSchema->name) {
+                if (!$schemaName) {
                     continue;
                 }
 
-                $schema = $gqlService->getSchemaById($schemaId);
+                if ($schemaName === 'public') {
+                    $schema = $publicSchema;
+                } else {
+                    $schemaId = GqlSchemaRecord::find()->select(['id'])->where(['name' => $schemaName])->scalar();
+                    if (!$schemaId) {
+                        continue;
+                    }
+                    $schema = $gqlService->getSchemaById($schemaId);
+                }
 
                 if ($schema) {
                     $schemaPermissions = $this->_getSchemaPermissions($schema);

--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -234,7 +234,7 @@ class RestrictionService extends Component
         }
 
         $schema = $this->getSchema();
-        $schemaCode = $schema->isPublic ? $schema->id : $schema->name;
+        $schemaCode = $schema->isPublic ? 'public' : $schema->name;
 
         $fieldPermissions = $fieldRestrictions['schema-' . $schemaCode] ?? [];
 

--- a/src/templates/_sections/fields.twig
+++ b/src/templates/_sections/fields.twig
@@ -18,7 +18,9 @@
         </th>
 
         {% for schema in schemaOptions %}
-          <th>{{ schema.label == '-' ? 'Public' : schema.label }}</th>
+          {% if schema.value != '' %}
+            <th>{{ schema.label }}</th>
+          {% endif %}
         {% endfor %}
       </tr>
     </thead>
@@ -36,19 +38,21 @@
           </td>
 
           {% for schema in schemaOptions %}
-            {% set schemaKey = 'schema-' ~ (schema.value != '' ? schema.value : '1') %}
+            {% if schema.value != '' %}
+              {% set schemaKey = 'schema-' ~ schema.value %}
 
-            <td style='vertical-align:top;padding-top:20px'>
-              {{ forms.selectField({
-                name: 'fieldRestrictions[' ~ schemaKey ~ '][' ~ field.handle ~ ']',
-                value: settings.fieldRestrictions[schemaKey][field.handle] ?? 'queryMutate',
-                options: [
-                  { value: 'queryMutate', label: 'Query & Mutate' },
-                  { value: 'query', label: 'Query' },
-                  { value: 'private', label: 'Private' },
-                ],
-              }) }}
-            </td>
+              <td style='vertical-align:top;padding-top:20px'>
+                {{ forms.selectField({
+                  name: 'fieldRestrictions[' ~ schemaKey ~ '][' ~ field.handle ~ ']',
+                  value: settings.fieldRestrictions[schemaKey][field.handle] ?? 'queryMutate',
+                  options: [
+                    { value: 'queryMutate', label: 'Query & Mutate' },
+                    { value: 'query', label: 'Query' },
+                    { value: 'private', label: 'Private' },
+                  ],
+                }) }}
+              </td>
+            {% endif %}
           {% endfor %}
         </tr>
       {% endfor %}


### PR DESCRIPTION
When testing the plugin we realized that the field restriction is only working when the public schema was the first schema created (id = 1). in our case we created non-public schemas first before adding the public schema resulting in ID 3. with this, the restriction was not working for unauthenticated users (using the public schema).

This PR fixes this issue by checking for `isPublic` instead of hardcoding a id of 1 for the public schema. Tested in Craft v5