### PR TITLE
fix: attach resolvers to „resolve“ method instead of not existing „resolver“ method

### DIFF
--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -121,7 +121,7 @@ class RestrictionService extends Component
 
         foreach ($resolvers as $name => $resolver) {
             if (isset($event->queries[$name])) {
-                $event->queries[$name]['resolver'] = $resolver;
+                $event->queries[$name]['resolve'] = $resolver;
             }
         }
     }


### PR DESCRIPTION
While testing the Plugin i realized that with authenticated users the "Restricted Entry Queries" was not working. Checking the commit from #161 I saw that the resolvers where attached to a non existing `resolver` method. This bugfix attaches the resolvers to the `resolve` method instead aligned to the craftcms docs: https://docs.craftcms.com/api/v5/craft-gql-base-resolver.html#method-resolve