### PR TITLE
feat: set section on dedicated sections queries

### DIFF
--- a/src/resolvers/Entry.php
+++ b/src/resolvers/Entry.php
@@ -22,6 +22,12 @@ use yii\base\UnknownMethodException;
  */
 class Entry extends ElementResolver
 {
+
+    /**
+     * Static property to store current section context
+     */
+    protected static ?string $sectionHandle = null;
+
     /**
      * @inheritdoc
      */
@@ -76,7 +82,7 @@ class Entry extends ElementResolver
         if ($restrictionService->shouldRestrictRequests()) {
             $user = GraphqlAuthentication::$tokenService->getUserFromToken();
 
-            if (isset($arguments['section']) || isset($arguments['sectionId'])) {
+            if (isset($arguments['section']) || isset($arguments['sectionId']) || isset(static::$sectionHandle)) {
                 $authorOnlySections = $user ? $restrictionService->getAuthorOnlySections($user, 'query') : [];
 
                 $entriesService = Craft::$app->getEntries();
@@ -87,6 +93,9 @@ class Entry extends ElementResolver
                     }
 
                     if (isset($arguments['sectionId']) && trim((string) $arguments['sectionId'][0]) !== $entriesService->getSectionByHandle($section)->id) {
+                        continue;
+                    }
+                    if (isset(static::$sectionHandle) && trim(static::$sectionHandle) !== $section) {
                         continue;
                     }
 
@@ -124,6 +133,24 @@ class Entry extends ElementResolver
             }
         }
 
+        if (static::$sectionHandle) {
+            $query->section(static::$sectionHandle);
+        }
+
         return $query;
+    }
+
+    public static function resolveWithSection($source, array $arguments, $context, $resolveInfo, $sectionHandle = null)
+    {
+        // Set the section handle for this execution
+        static::$sectionHandle = $sectionHandle;
+
+        // Call the parent (ElementResolver) resolve method
+        $result = parent::resolve($source, $arguments, $context, $resolveInfo);
+
+        // Reset the static property after use (for safety)
+        static::$sectionHandle = null;
+
+        return $result;
     }
 }

--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -115,8 +115,12 @@ class RestrictionService extends Component
 
         foreach (Craft::$app->getEntries()->getAllSections() as $section) {
             // "Entries" was added in Craft 5.6.5
-            $resolvers[$section->handle] = EntryResolver::class . '::resolve';
-            $resolvers["{$section->handle}Entries"] = EntryResolver::class . '::resolve';
+            $resolvers[$section->handle] = function ($source, $arguments, $context, $resolveInfo) use ($section) {
+                return EntryResolver::resolveWithSection($source, $arguments, $context, $resolveInfo, $section->handle);
+            };
+            $resolvers["{$section->handle}Entries"] = function ($source, $arguments, $context, $resolveInfo) use ($section) {
+                return EntryResolver::resolveWithSection($source, $arguments, $context, $resolveInfo, $section->handle);
+            };
         }
 
         foreach ($resolvers as $name => $resolver) {


### PR DESCRIPTION
the new dedicated sections queries like `newsEntries` are not working when the user is authenticated resulting in only news entries by the current user being returned. As we know the section handle when registering the resolver to GraphQL I guess its save to assume that we can filter by that section and not have to filter down to entries by the user. This PR introduces this fix.