### PR TITLE
feat: allow session only authentication

### DIFF
--- a/src/services/MagicService.php
+++ b/src/services/MagicService.php
@@ -139,10 +139,12 @@ class MagicService extends Component
             'args' => [
                 'code' => Type::nonNull(Type::int()),
                 'email' => Type::nonNull(Type::string()),
+                'sessionOnly' => Type::boolean(),
             ],
             'resolve' => function($source, array $arguments) use ($settings, $tokenService, $userService, $elementsService, $usersService, $errorService) {
                 $code = $arguments['code'];
                 $email = $arguments['email'];
+                $sessionOnly = $arguments['sessionOnly'] ?? false;
 
                 $this->_clearExpiredCodes();
                 /** @var MagicCode|null $magicCodeElement */
@@ -169,7 +171,7 @@ class MagicService extends Component
                 }
 
                 $elementsService->deleteElementById($magicCodeElement->id);
-                $token = $tokenService->create($user, $schemaId);
+                $token = $tokenService->create($user, $schemaId, $sessionOnly);
 
                 return $userService->getResponseFields($user, $schemaId, $token);
             },

--- a/src/services/TokenService.php
+++ b/src/services/TokenService.php
@@ -119,9 +119,11 @@ class TokenService extends Component
             'type' => Type::nonNull(Auth::getType()),
             'args' => [
                 'refreshToken' => Type::string(),
+                'sessionOnly' => Type::boolean(),
             ],
             'resolve' => function($source, array $arguments) use ($settings, $errorService) {
                 $refreshToken = $_COOKIE['gql_refreshToken'] ?? $arguments['refreshToken'] ?? null;
+                $sessionOnly = $arguments['sessionOnly'] ?? false;
 
                 if (!$refreshToken) {
                     $errorService->throw($settings->invalidRefreshToken);
@@ -150,7 +152,7 @@ class TokenService extends Component
 
                 $elementsService = Craft::$app->getElements();
                 $elementsService->deleteElementById($refreshTokenElement->id);
-                $token = $this->create($user, $schemaId);
+                $token = $this->create($user, $schemaId, $sessionOnly);
 
                 return GraphqlAuthentication::$userService->getResponseFields($user, $schemaId, $token);
             },
@@ -336,7 +338,7 @@ class TokenService extends Component
      * @return array
      * @throws Error
      */
-    public function create(User $user, int $schemaId)
+    public function create(User $user, int $schemaId, bool $sessionOnly = false)
     {
         $settings = GraphqlAuthentication::$settings;
         $errorService = GraphqlAuthentication::$errorService;
@@ -391,7 +393,7 @@ class TokenService extends Component
             $errorService->throw($errors[key($errors)][0]);
         }
 
-        $this->_setCookie('gql_refreshToken', $refreshToken, $settings->jwtRefreshExpiration);
+        $this->_setCookie('gql_refreshToken', $refreshToken, $sessionOnly ? null : $settings->jwtRefreshExpiration);
 
         return [
             'jwt' => $jwt->toString(),

--- a/src/services/TwoFactorService.php
+++ b/src/services/TwoFactorService.php
@@ -135,11 +135,13 @@ class TwoFactorService extends Component
                 'email' => Type::nonNull(Type::string()),
                 'password' => Type::nonNull(Type::string()),
                 'code' => Type::nonNull(Type::string()),
+                'sessionOnly' => Type::boolean(),
             ],
             'resolve' => function($source, array $arguments) use ($settings, $tokenService, $errorService, $usersService, $permissionsService) {
                 $email = $arguments['email'];
                 $password = $arguments['password'];
                 $code = $arguments['code'];
+                $sessionOnly = $arguments['sessionOnly'] ?? false;
 
                 if (!$user = $usersService->getUserByUsernameOrEmail($email)) {
                     $errorService->throw($settings->invalidLogin);
@@ -198,7 +200,7 @@ class TwoFactorService extends Component
                 }
 
                 $usersService->handleValidLogin($user);
-                $token = $tokenService->create($user, $schemaId);
+                $token = $tokenService->create($user, $schemaId, $sessionOnly);
 
                 return GraphqlAuthentication::$userService->getResponseFields($user, $schemaId, $token);
             },

--- a/src/services/UserService.php
+++ b/src/services/UserService.php
@@ -112,10 +112,12 @@ class UserService extends Component
             'args' => [
                 'email' => Type::nonNull(Type::string()),
                 'password' => Type::nonNull(Type::string()),
+                'sessionOnly' => Type::boolean(),
             ],
             'resolve' => function($source, array $arguments) use ($settings, $tokenService, $errorService, $usersService, $permissionsService) {
                 $email = $arguments['email'];
                 $password = $arguments['password'];
+                $sessionOnly = $arguments['sessionOnly'] ?? false;
 
                 if (!$user = $usersService->getUserByUsernameOrEmail($email)) {
                     $errorService->throw($settings->invalidLogin);
@@ -172,26 +174,26 @@ class UserService extends Component
                 $requiresTwoFactor = false;
 
                 // todo: add 2FA support
-//                if (
-//                    Craft::$app->plugins->isPluginEnabled('two-factor-authentication') &&
-//                    $settings->allowTwoFactorAuthentication
-//                ) {
-//                    /** @var Verify $verifyService */
-//                    $verifyService = TwoFactorAuth::$plugin->verify;
-//                    $requiresTwoFactor = $verifyService->isEnabled($user);
-//                }
-//
-//                if ($requiresTwoFactor) {
-//                    $token = [
-//                        'jwt' => null,
-//                        'jwtExpiresAt' => null,
-//                        'refreshToken' => null,
-//                        'refreshTokenExpiresAt' => null,
-//                    ];
-//                } else {
-                    $this->_updateLastLogin($user);
-                    $token = $tokenService->create($user, $schemaId);
-//                }
+                //                if (
+                //                    Craft::$app->plugins->isPluginEnabled('two-factor-authentication') &&
+                //                    $settings->allowTwoFactorAuthentication
+                //                ) {
+                //                    /** @var Verify $verifyService */
+                //                    $verifyService = TwoFactorAuth::$plugin->verify;
+                //                    $requiresTwoFactor = $verifyService->isEnabled($user);
+                //                }
+                //
+                //                if ($requiresTwoFactor) {
+                //                    $token = [
+                //                        'jwt' => null,
+                //                        'jwtExpiresAt' => null,
+                //                        'refreshToken' => null,
+                //                        'refreshTokenExpiresAt' => null,
+                //                    ];
+                //                } else {
+                $this->_updateLastLogin($user);
+                $token = $tokenService->create($user, $schemaId, $sessionOnly);
+                //                }
 
                 return $this->getResponseFields($user, $schemaId, $token, $requiresTwoFactor);
             },
@@ -208,18 +210,20 @@ class UserService extends Component
                         'username' => Type::string(),
                         'fullName' => Type::string(),
                         'preferredLanguage' => Type::string(),
+                        'sessionOnly' => Type::boolean(),
                     ],
                     $userArguments
                 ),
                 'resolve' => function($source, array $arguments) use ($settings, $tokenService, $errorService) {
                     $schemaId = GqlSchemaRecord::find()->select(['id'])->where(['name' => $settings->schemaName])->scalar();
+                    $sessionOnly = $arguments['sessionOnly'] ?? false;
 
                     if (!$schemaId) {
                         $errorService->throw($settings->invalidSchema);
                     }
 
                     $user = $this->create($arguments, $settings->userGroup);
-                    $token = $tokenService->create($user, $schemaId);
+                    $token = $tokenService->create($user, $schemaId, $sessionOnly);
 
                     return $this->getResponseFields($user, $schemaId, $token);
                 },
@@ -247,19 +251,21 @@ class UserService extends Component
                             'username' => Type::string(),
                             'fullName' => Type::string(),
                             'preferredLanguage' => Type::string(),
+                            'sessionOnly' => Type::boolean(),
                         ],
                         $userArguments
                     ),
                     'resolve' => function($source, array $arguments) use ($settings, $tokenService, $errorService, $userGroup) {
                         $schemaName = $settings->granularSchemas['group-' . $userGroup->id]['schemaName'] ?? null;
                         $schemaId = GqlSchemaRecord::find()->select(['id'])->where(['name' => $schemaName])->scalar();
+                        $sessionOnly = $arguments['sessionOnly'] ?? false;
 
                         if (!$schemaId) {
                             $errorService->throw($settings->invalidSchema);
                         }
 
                         $user = $this->create($arguments, $userGroup->id);
-                        $token = $tokenService->create($user, $schemaId);
+                        $token = $tokenService->create($user, $schemaId, $sessionOnly);
 
                         return $this->getResponseFields($user, $schemaId, $token);
                     },


### PR DESCRIPTION
adds an optional `sessionOnly` argument to the `authenticate` mutation. If set to true, a session cookie is created by not setting a expiry date.